### PR TITLE
Merge version June 2, 2012, suitable as module

### DIFF
--- a/sampler.py
+++ b/sampler.py
@@ -9,14 +9,6 @@ sampler_version = "November 14, 2011"
 # by Prof. Philip Stark (U.C. Berkeley) regarding election auditing.
 # Tested using python version 2.6.7.   (see www.python.org)
 # (Will not work with Python version 3, e.g. 3.x.y)
-# (Note added 2014-09-07: As per a suggestion by Chris Jerdonek, one should
-#  consider this proposal as based on the use of  UTF-8 encoding for strings 
-#  throughout.  This comment resolves some potential ambiguities about how 
-#  strings are converted to byte sequences before hashing, and the types of
-#  strings input by raw_input, etc.  See
-#    https://github.com/cjerdonek/rivest-sampler-tests
-# for more discussion and test-cases.
-# )
 
 """
 This program provides a reference implementation of a recommended procedure 

--- a/sampler.py
+++ b/sampler.py
@@ -3,12 +3,16 @@
 # Written by Ronald L. Rivest
 # filename: sampler.py
 # url: http://people.csail.mit.edu/rivest/sampler.py
-sampler_version = "November 14, 2011"
+sampler_version = "June 2, 2012"
 # 
 # Relevant to document being produced by an ad-hoc working group chaired
 # by Prof. Philip Stark (U.C. Berkeley) regarding election auditing.
 # Tested using python version 2.6.7.   (see www.python.org)
 # (Will not work with Python version 3, e.g. 3.x.y)
+#
+# This version (6/2/12) has printing_wanted set to False in generate_outputs,
+# but is otherwise the same as the November 2011 version.  This change was
+# made so that generate_outputs could be conveniently called from audit.py
 
 """
 This program provides a reference implementation of a recommended procedure 
@@ -369,7 +373,7 @@ def generate_outputs(n,with_replacement,a,b,seed,skip):
     new_output_list = [ ]
     old_output_list = [ ]
     count = 0        
-    printing_wanted = True
+    printing_wanted = False
     if printing_wanted:
         print "(6) Generating output:"
 
@@ -631,4 +635,5 @@ def main():
     print
     print "Done."
 
-main()
+if __name__=="__main__":
+    main()

--- a/sampler.py
+++ b/sampler.py
@@ -13,6 +13,15 @@ sampler_version = "June 2, 2012"
 # This version (6/2/12) has printing_wanted set to False in generate_outputs,
 # but is otherwise the same as the November 2011 version.  This change was
 # made so that generate_outputs could be conveniently called from audit.py
+#
+# (Note added 2014-09-07: As per a suggestion by Chris Jerdonek, one should
+#  consider this proposal as based on the use of  UTF-8 encoding for strings 
+#  throughout.  This comment resolves some potential ambiguities about how 
+#  strings are converted to byte sequences before hashing, and the types of
+#  strings input by raw_input, etc.  See
+#    https://github.com/cjerdonek/rivest-sampler-tests
+# for more discussion and test-cases.
+# )
 
 """
 This program provides a reference implementation of a recommended procedure 


### PR DESCRIPTION
In preparation for being able to run the tests from this python implementation of the PRNG method,
this patch makes `python.py` suitable for use as a module, called from other python code,
by only executing `main()` if` __name__` is `"__main__"`.
A version of the code that does that, and also turns off printing, was previously
available as `sampler_version = "June 2, 2012"`, so we just had to merge that in.
For the record, this branch's version history also has the version of sampler from `November 14, 2011`.
 